### PR TITLE
Fix missing alarm when the main activity is running

### DIFF
--- a/src/com/bourke/kitchentimer/ui/MainActivity.java
+++ b/src/com/bourke/kitchentimer/ui/MainActivity.java
@@ -444,7 +444,7 @@ public class MainActivity extends Activity {
         public void run() {
             long remainingSeconds = timerSeconds[timer] - (SystemClock.elapsedRealtime() - timerStartTime[timer]) / 1000;
             tvTimer[timer].setText(Utils.formatTime(Math.max(remainingSeconds, 0L), timer));
-            if (remainingSeconds <= 0) {
+            if (remainingSeconds < 0) {
                 setTimerState(false, timer);
                 if (mPrefs.getBoolean(getString(R.string.pref_clear_timer_label_key), false)){
                     tvTimerLabel[timer].setText(timerDefaultName[timer]);


### PR DESCRIPTION
In `MyRunnable.run()` the alarm is canceled via `setTimerState(false,..)` just before the broadcast intent can fire. This happens within the same second.
